### PR TITLE
lua: redis support expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ server_id=1 # 配置 MySQL replaction 需要定义，不要和 go-mysql-transfer
 
 # 更新日志
 
-**v1.0.0 bate**
+**v1.0.0 beta**
 
-* 9.17  初始化提交bate版本
+* 9.17  初始化提交beta版本
 
 **v1.0.1 release**
 

--- a/service/endpoint/redis.go
+++ b/service/endpoint/redis.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-redis/redis"
 	"github.com/pingcap/errors"
@@ -264,6 +265,12 @@ func (s *RedisEndpoint) preparePipe(resp *model.RedisRespond, pipe redis.Cmdable
 		} else {
 			val := redis.Z{Score: resp.Score, Member: resp.Val}
 			pipe.ZAdd(resp.Key, val)
+		}
+	default:
+		if resp.Action == "expire" {
+			vv, _ := resp.Val.(float64)
+			var s int64 = int64(vv) * 1000000000 //trans to ns
+			pipe.Expire(resp.Key, time.Duration(s))
 		}
 	}
 }

--- a/service/luaengine/redis_actuator.go
+++ b/service/luaengine/redis_actuator.go
@@ -54,12 +54,22 @@ var _redisModuleApi = map[string]lua.LGFunction{
 
 	"ZADD": redisZAdd,
 	"ZREM": redisZRem,
+
+	"EXPIRE": redisExpire,
 }
 
 func rawOldRow(L *lua.LState) int {
 	row := L.GetGlobal(_globalOLDROW)
 	L.Push(row)
 	return 1
+}
+
+func redisExpire(L *lua.LState) int {
+	key := L.CheckString(1)
+	val := L.CheckAny(2)
+	ret := L.GetGlobal(_globalRET)
+	L.SetTable(ret, lua.LString("expire_0_"+key), val)
+	return 0
 }
 
 func redisSet(L *lua.LState) int {


### PR DESCRIPTION
lua: redis support expire, eg: 

local ops = require("redisOps") --加载redis操作模块
local row = ops.rawRow()  --当前数据库的一行数据,table类型，key为列名称
local action = ops.rawAction()  --当前数据库事件,包括：insert、update、delete
local key = tostring(row["id"])
if action == "insert" or action == "update" -- 监听insert update事件
then
    for k, v in pairs(row) do
	    ops.HSET(key,k,v) 
	end
	
	**ops.EXPIRE(key, 200)  --设置过期时间**
else-- 监听删除事件
    ops.DEL(key) -- 删除旧值
end