### PR TITLE
fix!: 组合主键格式修复

### DIFF
--- a/service/endpoint/endpoint.go
+++ b/service/endpoint/endpoint.go
@@ -306,19 +306,21 @@ func oldRowMap(req *model.RowRequest, rule *global.Rule, primitive bool) map[str
 	return kv
 }
 
+// primaryKey 自适应获取主键
 func primaryKey(re *model.RowRequest, rule *global.Rule) interface{} {
-	if rule.IsCompositeKey { // 组合ID
-		var key string
+	if rule.IsCompositeKey {
+		vList := make([]string, 0)
 		for _, index := range rule.TableInfo.PKColumns {
-			key += stringutil.ToString(re.Row[index])
+			vList = append(vList, stringutil.ToString(re.Row[index]))
 		}
-		return key
-	} else {
-		index := rule.TableInfo.PKColumns[0]
-		data := re.Row[index]
-		column := rule.TableInfo.Columns[index]
-		return convertColumnData(data, &column, rule)
+		return strings.Join(vList, "_")
 	}
+
+	index := rule.TableInfo.PKColumns[0]
+	data := re.Row[index]
+	column := rule.TableInfo.Columns[index]
+
+	return convertColumnData(data, &column, rule)
 }
 
 func elsHosts(addr string) []string {

--- a/service/endpoint/endpoint.go
+++ b/service/endpoint/endpoint.go
@@ -309,9 +309,9 @@ func oldRowMap(req *model.RowRequest, rule *global.Rule, primitive bool) map[str
 // primaryKey 自适应获取主键
 func primaryKey(re *model.RowRequest, rule *global.Rule) interface{} {
 	if rule.IsCompositeKey {
-		vList := make([]string, 0)
+		vList := make([]string, len(rule.TableInfo.PKColumns))
 		for _, index := range rule.TableInfo.PKColumns {
-			vList = append(vList, stringutil.ToString(re.Row[index]))
+			vList[index] = stringutil.ToString(re.Row[index])
 		}
 		return strings.Join(vList, "_")
 	}


### PR DESCRIPTION
组合主键方法 `primaryKey()` 在这两种情况下取到的都是 "999"
1. pk1=9, pk2=99
2. pk1=99, pk2=9

修改后:
1. "9_99"
2. "99_9"